### PR TITLE
Update unstable symlinks for 2021.01.rc0-py36

### DIFF
--- a/symlink_config.json
+++ b/symlink_config.json
@@ -12,7 +12,7 @@
         "unstable-py2": "unstable-py27",
         "unstable-py27": "2021.01.rc0-py27",
         "unstable-py3": "unstable-py36",
-        "unstable-py36": "2020.01.a1-py36"
+        "unstable-py36": "2021.01.rc0-py36"
     },
     "root_folder": "/prog/res/komodo",
     "root_links": [


### PR DESCRIPTION
:robot: Suggesting updating unstable to 2021.01.rc0-py36 in symlink_config.json
---
### Description
- Release: `2021.01.rc0-py36`
- Mode: `unstable`
- When: 2020-02-06 08:31:38.022463

### Details
_This pull request was generated by [KOMDO PR FOO](http://example.org)_. Source code for
this script can be found [here](https://github.com/equinor/komodo).
